### PR TITLE
Update package.json - move @babel/runtime to devDeps as it is not reqired in runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "url": "https://github.com/overlookmotel/is-it-type/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.7",
     "globalthis": "^1.0.2"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.16.7",
     "@babel/core": "^7.16.12",
     "@babel/plugin-transform-runtime": "^7.16.10",
     "@babel/preset-env": "^7.16.11",


### PR DESCRIPTION
I noticed awhile ago that this package depends on @babel/runtime but does not use it. It also took up a moderate amount of space, so I made this pr.